### PR TITLE
Use SerializedObject in generator editors

### DIFF
--- a/TerrainGenerator/Assets/Editor/MapGeneratorEditor.cs
+++ b/TerrainGenerator/Assets/Editor/MapGeneratorEditor.cs
@@ -8,57 +8,64 @@ public class MapGeneratorEditor : Editor
 {
     public override void OnInspectorGUI()
     {
-        MapGenerator mapGen = (MapGenerator) target;
+        serializedObject.Update();
 
         EditorGUI.BeginChangeCheck();
+
         EditorGUILayout.LabelField("Size", EditorStyles.boldLabel);
-        mapGen.mapSize = EditorGUILayout.IntSlider("Map size:", mapGen.mapSize, 100, 1000);
+        SerializedProperty mapSizeProp = serializedObject.FindProperty("mapSize");
+        mapSizeProp.intValue = EditorGUILayout.IntSlider("Map size:", mapSizeProp.intValue, 100, 1000);
         EditorGUILayout.Space();
 
         EditorGUILayout.LabelField("General settings", EditorStyles.boldLabel);
-        mapGen.autoUpdate = GUILayout.Toggle(mapGen.autoUpdate, "Auto update");
-        mapGen.generateWater = GUILayout.Toggle(mapGen.generateWater, "Generate water");
-        
-        if (mapGen.generateWater)
+        SerializedProperty autoUpdateProp = serializedObject.FindProperty("autoUpdate");
+        autoUpdateProp.boolValue = GUILayout.Toggle(autoUpdateProp.boolValue, "Auto update");
+        SerializedProperty generateWaterProp = serializedObject.FindProperty("generateWater");
+        generateWaterProp.boolValue = GUILayout.Toggle(generateWaterProp.boolValue, "Generate water");
+
+        if (generateWaterProp.boolValue)
         {
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("Water settings", EditorStyles.boldLabel);
-
-            mapGen.waterGenerator =
-                EditorGUILayout.ObjectField("Water generator:", mapGen.waterGenerator, typeof(WaterGenerator), true) as
-                    WaterGenerator;
-            mapGen.waterLevel = EditorGUILayout.Slider("Water level:", mapGen.waterLevel, 0.01f, 5f);
+            SerializedProperty waterGeneratorProp = serializedObject.FindProperty("waterGenerator");
+            EditorGUILayout.PropertyField(waterGeneratorProp, new GUIContent("Water generator"));
+            SerializedProperty waterLevelProp = serializedObject.FindProperty("waterLevel");
+            waterLevelProp.floatValue = EditorGUILayout.Slider("Water level:", waterLevelProp.floatValue, 0.01f, 5f);
             EditorGUILayout.Space();
         }
-        
-        mapGen.island = GUILayout.Toggle(mapGen.island, "Generate island:");
 
-        if (mapGen.island)
+        SerializedProperty islandProp = serializedObject.FindProperty("island");
+        islandProp.boolValue = GUILayout.Toggle(islandProp.boolValue, "Generate island:");
+
+        if (islandProp.boolValue)
         {
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("Island settings", EditorStyles.boldLabel);
-            mapGen.islandSizeMultiplier = EditorGUILayout.Slider("Island size:", mapGen.islandSizeMultiplier, .5f, 2);
-            mapGen.islandMin = EditorGUILayout.Slider("Island fallout:", mapGen.islandMin, 0, 1);
+            SerializedProperty islandSizeProp = serializedObject.FindProperty("islandSizeMultiplier");
+            islandSizeProp.floatValue = EditorGUILayout.Slider("Island size:", islandSizeProp.floatValue, .5f, 2f);
+            SerializedProperty islandMinProp = serializedObject.FindProperty("islandMin");
+            islandMinProp.floatValue = EditorGUILayout.Slider("Island fallout:", islandMinProp.floatValue, 0f, 1f);
         }
 
         EditorGUILayout.Space();
 
         EditorGUILayout.LabelField("Point sampling", EditorStyles.boldLabel);
-        mapGen.distributionData.distributionType =
-            (DistributionType) EditorGUILayout.EnumPopup("Vertex distribution type:",
-                mapGen.distributionData.distributionType);
+        SerializedProperty distributionDataProp = serializedObject.FindProperty("distributionData");
+        SerializedProperty distTypeProp = distributionDataProp.FindPropertyRelative("distributionType");
+        distTypeProp.enumValueIndex = (int)(DistributionType)EditorGUILayout.EnumPopup("Vertex distribution type:",
+            (DistributionType)distTypeProp.enumValueIndex);
 
-        switch (mapGen.distributionData.distributionType)
+        switch ((DistributionType)distTypeProp.enumValueIndex)
         {
             case DistributionType.Random:
-                mapGen.distributionData.pointDensity = EditorGUILayout.IntSlider("Point density:",
-                    mapGen.distributionData.pointDensity, 500, 1000);
+                SerializedProperty pointDensityProp = distributionDataProp.FindPropertyRelative("pointDensity");
+                pointDensityProp.intValue = EditorGUILayout.IntSlider("Point density:", pointDensityProp.intValue, 500, 1000);
                 break;
             case DistributionType.Poisson:
-                mapGen.distributionData.radius =
-                    EditorGUILayout.Slider("Radius between vertex:", mapGen.distributionData.radius, 7f, 30f);
-                mapGen.distributionData.rejectionSamples = EditorGUILayout.IntSlider("Rejection samples:",
-                    mapGen.distributionData.rejectionSamples, 5, 50);
+                SerializedProperty radiusProp = distributionDataProp.FindPropertyRelative("radius");
+                radiusProp.floatValue = EditorGUILayout.Slider("Radius between vertex:", radiusProp.floatValue, 7f, 30f);
+                SerializedProperty rejectionProp = distributionDataProp.FindPropertyRelative("rejectionSamples");
+                rejectionProp.intValue = EditorGUILayout.IntSlider("Rejection samples:", rejectionProp.intValue, 5, 50);
                 break;
             default:
                 throw new ArgumentOutOfRangeException();
@@ -67,31 +74,57 @@ public class MapGeneratorEditor : Editor
         EditorGUILayout.Space();
 
         EditorGUILayout.LabelField("Noise settings", EditorStyles.boldLabel);
-        mapGen.noiseData.meshHeightMultiplier =
-            EditorGUILayout.Slider("Mesh height:", mapGen.noiseData.meshHeightMultiplier, 0.0001f, 300);
-        mapGen.noiseData.noiseScale =
-            EditorGUILayout.Slider("Noise scale:", mapGen.noiseData.noiseScale, 0.0001f, 10000f);
-        mapGen.noiseData.meshHeightCurve =
-            EditorGUILayout.CurveField("Height curve:", mapGen.noiseData.meshHeightCurve);
-        mapGen.noiseData.octaves = EditorGUILayout.IntSlider("Octaves:", mapGen.noiseData.octaves, 1, 5);
-        mapGen.noiseData.persistenceType =
-            (PersistenceType) EditorGUILayout.EnumPopup("Persistence type:", mapGen.noiseData.persistenceType);
-        mapGen.noiseData.lacunarity = EditorGUILayout.Slider("Lacunarity:", mapGen.noiseData.lacunarity, 1f, 5f);
-        mapGen.noiseData.seed = EditorGUILayout.IntField("Seed:", mapGen.noiseData.seed);
-        mapGen.noiseData.offset = EditorGUILayout.Vector2Field("Offset:", mapGen.noiseData.offset);
+        SerializedProperty noiseDataProp = serializedObject.FindProperty("noiseData");
+        SerializedProperty meshHeightProp = noiseDataProp.FindPropertyRelative("meshHeightMultiplier");
+        meshHeightProp.floatValue = EditorGUILayout.Slider("Mesh height:", meshHeightProp.floatValue, 0.0001f, 300f);
+        SerializedProperty noiseScaleProp = noiseDataProp.FindPropertyRelative("noiseScale");
+        noiseScaleProp.floatValue = EditorGUILayout.Slider("Noise scale:", noiseScaleProp.floatValue, 0.0001f, 10000f);
+        SerializedProperty heightCurveProp = noiseDataProp.FindPropertyRelative("meshHeightCurve");
+        EditorGUILayout.PropertyField(heightCurveProp, new GUIContent("Height curve"));
+        SerializedProperty octavesProp = noiseDataProp.FindPropertyRelative("octaves");
+        octavesProp.intValue = EditorGUILayout.IntSlider("Octaves:", octavesProp.intValue, 1, 5);
+        SerializedProperty persistenceProp = noiseDataProp.FindPropertyRelative("persistenceType");
+        persistenceProp.enumValueIndex = (int)(PersistenceType)EditorGUILayout.EnumPopup("Persistence type:",
+            (PersistenceType)persistenceProp.enumValueIndex);
+        SerializedProperty lacunarityProp = noiseDataProp.FindPropertyRelative("lacunarity");
+        lacunarityProp.floatValue = EditorGUILayout.Slider("Lacunarity:", lacunarityProp.floatValue, 1f, 5f);
+        SerializedProperty seedProp = noiseDataProp.FindPropertyRelative("seed");
+        seedProp.intValue = EditorGUILayout.IntField("Seed:", seedProp.intValue);
+        SerializedProperty offsetProp = noiseDataProp.FindPropertyRelative("offset");
+        offsetProp.vector2Value = EditorGUILayout.Vector2Field("Offset:", offsetProp.vector2Value);
         EditorGUILayout.Space();
 
-
+        bool changed = EditorGUI.EndChangeCheck();
+        serializedObject.ApplyModifiedProperties();
 
         EditorGUILayout.BeginHorizontal();
         if (GUILayout.Button("Generate random seed"))
         {
-            mapGen.GenerateRandomSeed();
+            foreach (MapGenerator generator in targets)
+            {
+                generator.GenerateRandomSeed();
+            }
         }
-        if (mapGen.autoUpdate && EditorGUI.EndChangeCheck()||GUILayout.Button ("Generate"))
-        {
-            mapGen.GenerateMap ();
-        }
+        bool manualGenerate = GUILayout.Button("Generate");
         EditorGUILayout.EndHorizontal();
+
+        if (changed)
+        {
+            foreach (MapGenerator generator in targets)
+            {
+                if (generator.autoUpdate)
+                {
+                    generator.GenerateMap();
+                }
+            }
+        }
+
+        if (manualGenerate)
+        {
+            foreach (MapGenerator generator in targets)
+            {
+                generator.GenerateMap();
+            }
+        }
     }
 }

--- a/TerrainGenerator/Assets/Editor/WaterGeneratorEditor.cs
+++ b/TerrainGenerator/Assets/Editor/WaterGeneratorEditor.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEditor;
+﻿using UnityEditor;
 using UnityEngine;
 
 [CustomEditor(typeof(WaterGenerator))]
@@ -8,16 +6,24 @@ public class WaterGeneratorEditor : Editor
 {
     public override void OnInspectorGUI() 
     {
-        WaterGenerator mapGen = (WaterGenerator)target;
+        serializedObject.Update();
 
-        if (DrawDefaultInspector()) 
+        if (DrawDefaultInspector())
         {
-            mapGen.GenerateWater();
+            foreach (WaterGenerator gen in targets)
+            {
+                gen.GenerateWater();
+            }
         }
 
-        if (GUILayout.Button ("Update")) 
+        serializedObject.ApplyModifiedProperties();
+
+        if (GUILayout.Button("Update"))
         {
-            mapGen.GenerateWater();
+            foreach (WaterGenerator gen in targets)
+            {
+                gen.GenerateWater();
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- refactor MapGeneratorEditor to use SerializedObject/SerializedProperty and support multi-object updates
- wrap WaterGeneratorEditor inspector with SerializedObject for undo/redo

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8cc9172c83208d45602675fa4e32