### PR TITLE
Use Unity sqrMagnitude in point sampling

### DIFF
--- a/TerrainGenerator/Assets/Scripts/PointSampling.cs
+++ b/TerrainGenerator/Assets/Scripts/PointSampling.cs
@@ -67,7 +67,7 @@ public static class PointSampling
                     int pointIndex = grid[x, y] - 1;
                     if (pointIndex != -1)
                     {
-                        float sqrDst = (candidate - points[pointIndex]).SqrMagnitude();
+                        float sqrDst = (candidate - points[pointIndex]).sqrMagnitude;
                         if (sqrDst <= r * r)
                         {
                             return false;


### PR DESCRIPTION
## Summary
- use Vector2.sqrMagnitude instead of deprecated SqrMagnitude in point sampling validation

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8cc7feac832084603d92ed2fefc8