### PR TITLE
chore: update Unity package versions

### DIFF
--- a/TerrainGenerator/Packages/manifest.json
+++ b/TerrainGenerator/Packages/manifest.json
@@ -1,11 +1,10 @@
 {
   "dependencies": {
-    "com.unity.collab-proxy": "1.2.16",
-    "com.unity.ide.rider": "1.1.4",
-    "com.unity.ide.vscode": "1.2.0",
-    "com.unity.test-framework": "1.1.13",
-    "com.unity.textmeshpro": "2.0.1",
-    "com.unity.timeline": "1.2.14",
+    "com.unity.ide.rider": "3.0.16",
+    "com.unity.ide.vscode": "1.2.5",
+    "com.unity.test-framework": "1.1.33",
+    "com.unity.textmeshpro": "3.0.6",
+    "com.unity.timeline": "1.6.4",
     "com.unity.ugui": "1.0.0",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",


### PR DESCRIPTION
## Summary
- remove deprecated collab-proxy package
- bump Unity packages (TextMeshPro, Timeline, test framework, IDE tools)

## Testing
- `Unity -batchmode -quit -nographics -projectPath TerrainGenerator` (command not found)
- `npm test` (fails: ENOENT: no such file or directory, open '/workspace/TerrainGenerator/package.json')

------
https://chatgpt.com/codex/tasks/task_e_68ac8cc70eb483208b6ef40df35c5c3e